### PR TITLE
[UPDATE] add dockerfile & use classpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:22-jdk
+VOLUME /tmp
+COPY target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/java/com/immobylette/api/photo/resource/GCSResource.java
+++ b/src/main/java/com/immobylette/api/photo/resource/GCSResource.java
@@ -4,9 +4,10 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.*;
 import com.immobylette.api.photo.config.GCSconfig;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
-import java.io.FileInputStream;
+import org.springframework.core.io.Resource;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -22,8 +23,11 @@ public class GCSResource {
     }
 
     private void setup() throws IOException {
+         Resource resource = new ClassPathResource(this.gcsConfig.getCredentialsLocation());
+         resource.getFilename();
+
         Credentials credentials = GoogleCredentials
-                .fromStream(new FileInputStream(this.gcsConfig.getCredentialsLocation()));
+                .fromStream(resource.getInputStream());
 
         this.storage = StorageOptions.newBuilder().setCredentials(credentials)
                 .setProjectId(this.gcsConfig.getProjectId()).build().getService();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,4 +28,4 @@ server:
 gcs:
   project-id: ${GCP_PROJECT_ID:immobylette}
   bucket-name: ${GCP_BUCKET_NAME:immobylette--photos}
-  credentials-location: ${GCP_CREDENTIALS_LOCATION:immobylette-credentials.json}
+  credentials-location: immobylette-credentials.json


### PR DESCRIPTION
plus besoin de mettre le path absolue du fichier des credentials dans l'application.yml car quand on build avec maven, le fichier arrive dans target/classes et donc on peut y accéder en utilisant ClassPathResource.

C'est utile quand on lance l'app dans le conteneur car ducoup le path n'était plus bon