### PR TITLE
[ADD] added get photo from a folder endpoint

### DIFF
--- a/src/main/java/com/immobylette/api/photo/controller/PhotoController.java
+++ b/src/main/java/com/immobylette/api/photo/controller/PhotoController.java
@@ -23,6 +23,6 @@ public class PhotoController {
 
     @GetMapping("/photos/{folderId}/{photoId}")
     public PhotoDto getPhoto(@PathVariable UUID folderId, @PathVariable UUID photoId) throws PhotoNotFoundException, GCPStorageException {
-        return photoService.getPhoto(folderId, photoId);
+        return photoService.getPhotoInFolder(folderId, photoId);
     }
 }

--- a/src/main/java/com/immobylette/api/photo/controller/PhotoController.java
+++ b/src/main/java/com/immobylette/api/photo/controller/PhotoController.java
@@ -20,4 +20,9 @@ public class PhotoController {
     public PhotoDto getPhoto(@PathVariable UUID id) throws PhotoNotFoundException, GCPStorageException {
         return photoService.getPhoto(id);
     }
+
+    @GetMapping("/photos/{folderId}/{photoId}")
+    public PhotoDto getPhoto(@PathVariable UUID folderId, @PathVariable UUID photoId) throws PhotoNotFoundException, GCPStorageException {
+        return photoService.getPhoto(folderId, photoId);
+    }
 }

--- a/src/main/java/com/immobylette/api/photo/service/PhotoService.java
+++ b/src/main/java/com/immobylette/api/photo/service/PhotoService.java
@@ -33,6 +33,13 @@ public class PhotoService {
         return photoMapper.fromPhoto(photo, url);
     }
 
+    public PhotoDto getPhoto(UUID folderId, UUID photoId) throws PhotoNotFoundException{
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new PhotoNotFoundException(photoId));
+        URL url = gcsResource.getSignedUrl(String.format("%s/%s", folderId, photoId));
+
+        return photoMapper.fromPhoto(photo, url);
+    }
+
     public PhotoDto getPhotoInFolder(UUID folder, UUID photoId) throws PhotoNotFoundException {
         Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new PhotoNotFoundException(photoId));
         URL url = gcsResource.getSignedUrl(String.format("%s/%s", folder, photoId));

--- a/src/main/java/com/immobylette/api/photo/service/PhotoService.java
+++ b/src/main/java/com/immobylette/api/photo/service/PhotoService.java
@@ -33,13 +33,6 @@ public class PhotoService {
         return photoMapper.fromPhoto(photo, url);
     }
 
-    public PhotoDto getPhoto(UUID folderId, UUID photoId) throws PhotoNotFoundException{
-        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new PhotoNotFoundException(photoId));
-        URL url = gcsResource.getSignedUrl(String.format("%s/%s", folderId, photoId));
-
-        return photoMapper.fromPhoto(photo, url);
-    }
-
     public PhotoDto getPhotoInFolder(UUID folder, UUID photoId) throws PhotoNotFoundException {
         Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new PhotoNotFoundException(photoId));
         URL url = gcsResource.getSignedUrl(String.format("%s/%s", folder, photoId));


### PR DESCRIPTION
J'ai du ajouté un nouvel endpoint car : 
- la photo de base d'un élément se situe dans le dossier de ses photos de bases. Pour accéder à l'objet dans le bucket il faut donc faire : folderId/imageId sauf que cela n'était actuellement pas possible

Note : le miro a été mis à jour

Cela veut donc dire que lorsque l'on va récupérer les photos de base d'un élément il y aura inclus; la photo de base mais cela n'est pas vraiment gênant.